### PR TITLE
Added Docker deployment for WebGL builds

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3.8'
+
+services:
+  webgl:
+    container_name: unity-webgl-demo
+    image: unity-webgl-demo
+    build: .
+    ports:
+      - "1111:1111"

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:alpine
+
+WORKDIR /etc/nginx/conf.d
+COPY webgl.conf default.conf
+
+WORKDIR /UnityWebGLBuilds
+COPY UnityWebGLBuilds/ .

--- a/webgl.conf
+++ b/webgl.conf
@@ -1,0 +1,18 @@
+server {
+    listen       1111;
+    server_name  localhost;
+
+    location / {
+        root   /UnityWebGLBuilds;
+        index  index.html;
+    }
+
+    error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Support added for Docker based web app.

A containerized solution will allow for quick and scalable deployment to cloud with Kubernetes.

WebGL Build files should be placed in ```./UnityWebGLBuilds```

```docker compose up --build```

Traffic served on ```localhost:1111``` with nginx